### PR TITLE
display category icons and content cards after seed updates

### DIFF
--- a/app/assets/stylesheets/pages/_itineraries_show.scss
+++ b/app/assets/stylesheets/pages/_itineraries_show.scss
@@ -13,6 +13,9 @@
     width: 50%;
 
     @media (max-width: 1040px) {
+      .days-container .category-container {
+        min-height: 2.7rem;
+      }
       .items-container {
         gap: 0.4rem;
       }
@@ -61,6 +64,10 @@
 
 .days-container {
   padding-bottom: 8px;
+
+  .category-container {
+    min-height: 3rem;
+  }
 
   &:last-child {
     padding-bottom: 0;

--- a/app/views/itineraries/_category_icon.html.erb
+++ b/app/views/itineraries/_category_icon.html.erb
@@ -1,18 +1,13 @@
-<% if category == "morning_activity" || category == "afternoon_activity" %>
+<% if category == "Activity" %>
   <div class="category-icon">
     <i class="fa-solid fa-camera"></i>
   </div>
-<% elsif category == "lunch" || category == "dinner" %>
+<% elsif category == "Restaurant" %>
   <div class="category-icon">
     <i class="fa-solid fa-utensils"></i>
   </div>
-<% elsif category == "accommodation" %>
+<% elsif category == "Accommodation" %>
   <div class="category-icon">
     <i class="fa-solid fa-bed"></i>
   </div>
 <% end %>
-<!--
-<div class="category-icon">
-  <i class="fa-solid fa-bus-simple"></i>
-</div>
--->

--- a/app/views/itineraries/_content.html.erb
+++ b/app/views/itineraries/_content.html.erb
@@ -2,7 +2,7 @@
   <div class="card-body">
     <div class="d-flex">
       <div class="me-3">
-        <%= render 'category_icon', category: content.category %>
+        <%= render 'category_icon', category: content.category.title %>
       </div>
       <div class="flex-column flex-grow-1">
         <div class="d-flex justify-content-between">
@@ -17,10 +17,10 @@
         <p class="card-text line-clamp"><%= content.description %></p>
         <div class="d-flex justify-content-between">
           <p class="m-0 user-select-none">
-            <% content.rating.times do %>
+            <% content.rating.to_i.times do %>
               <i class="fa-solid fa-star"></i>
             <% end %>
-            <% (5 - content.rating).times do %>
+            <% (5 - content.rating.to_i).times do %>
               <i class="fa-regular fa-star"></i>
             <% end %>
           </p>

--- a/app/views/itineraries/_day.html.erb
+++ b/app/views/itineraries/_day.html.erb
@@ -3,7 +3,7 @@
     <div class="category-container p-2">
       <h2>Day <%= day.number %></h2>
       <% day.contents.each do |content| %>
-        <%= render 'category_icon', category: content.category %>
+        <%= render 'category_icon', category: content.category.title %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
@hafid-Qa 
I updated the view after Fred updated the seeds,
but I think I need some help to fix the tabs.


<img width="777" alt="Screen Shot 2022-11-24 at 8 43 45" src="https://user-images.githubusercontent.com/109743083/203664468-092b6382-e3f1-41f8-8cbd-6563ce7653c1.png">
<img width="776" alt="Screen Shot 2022-11-24 at 8 43 49" src="https://user-images.githubusercontent.com/109743083/203664469-29d26b96-23fd-4359-a9cf-3824aae9cb75.png">
<img width="667" alt="Screen Shot 2022-11-24 at 8 43 53" src="https://user-images.githubusercontent.com/109743083/203664472-74071aff-8aaf-4006-b1e2-8984bc1d8e18.png">
