### PR TITLE
added groover option to display background colors on pdf

### DIFF
--- a/app/controllers/itineraries_controller.rb
+++ b/app/controllers/itineraries_controller.rb
@@ -100,7 +100,7 @@ class ItinerariesController < ApplicationController
                                                         layout: 'pdf',
                                                         locals: { itinerary: @itinerary }
                                                       })
-    pdf = Grover.new(html, display_url: ENV.fetch("host_name").to_s).to_pdf
+    pdf = Grover.new(html, display_url: ENV.fetch("host_name").to_s, print_background: true).to_pdf
     send_data(pdf,
               filename: "#{@itinerary.title}- #{@itinerary.client.name} ",
               type: 'application/pdf')


### PR DESCRIPTION
<img width="908" alt="Screen Shot 2022-12-01 at 9 01 19" src="https://user-images.githubusercontent.com/113567278/204933836-469fd1b6-80a8-449b-b5c6-2b82387809a8.png">

background colors are now appearing on pdf also.